### PR TITLE
FIX: Fix bug caused by not hashing new pwd in modifyPassword.php

### DIFF
--- a/src/user/modifyPassword.php
+++ b/src/user/modifyPassword.php
@@ -29,10 +29,11 @@
         $result = $stmt->fetchAll();
         if($result != NULL && $checkedPassword == $Password)
         {
+            $hashedPassword = password_hash($Password, PASSWORD_DEFAULT);
             $query = ("update reader set Password=?
                     where Reader_ID=? and Name=?");
             $stmt= $db->prepare($query);//執行SQL語法
-            $result = $stmt->execute(array($Password, $Reader_ID, $Name));
+            $result = $stmt->execute(array($hashedPassword, $Reader_ID, $Name));
             echo "edit succeed";
         }
         else{


### PR DESCRIPTION
## Types of changes
**Thanks for sending a pull request! Please fill in the following content to let us know better about this change.**
Please put an `x` in the box that applies

- [x] **Bugfix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description
**Describe what the change is**
In modify password, hash password before inserting into database

## Expected behavior
Able to login successfully after modifying password

## Related Issue
close #49 
